### PR TITLE
refactor(thymeleaf): streamline tailwind config in fragment

### DIFF
--- a/src/main/webapp/WEB-INF/templates/courses/list.html
+++ b/src/main/webapp/WEB-INF/templates/courses/list.html
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="fr">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <th:block th:replace="~{fragments/head :: head}"></th:block>
     <title>Courses - Color Run</title>
-    <link rel="stylesheet" th:href="|${contextPath}/resources/css/main.css|" />
   </head>
   <body>
     <!-- Header -->

--- a/src/main/webapp/WEB-INF/templates/dashboard.html
+++ b/src/main/webapp/WEB-INF/templates/dashboard.html
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="fr">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <th:block th:replace="~{fragments/head :: head}"></th:block>
     <title>Tableau de bord - Color Run</title>
-    <link rel="stylesheet" th:href="|${contextPath}/resources/css/main.css|" />
   </head>
   <body>
     <!-- Header -->
@@ -12,7 +10,7 @@
 
     <!-- Main content -->
     <div class="container">
-      <h1>Tableau de bord</h1>
+      <h1 class="text-red-500">Tableau de bord</h1>
 
       <!-- Alertes -->
       <div

--- a/src/main/webapp/WEB-INF/templates/fragments/head.html
+++ b/src/main/webapp/WEB-INF/templates/fragments/head.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body>
+  <th:block th:fragment="head">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title th:text="${pageTitle != null ? pageTitle : 'Color Run'}">Color Run</title>
+    
+    <!-- TailwindCSS -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              'color-primary': '#FF6B35',
+              'color-secondary': '#F7931E',
+              'color-accent': '#FFE135',
+              'color-pink': '#FF006E',
+              'color-purple': '#8338EC',
+              'color-blue': '#3A86FF',
+              'color-green': '#06FFA5',
+            }
+          }
+        }
+      }
+    </script>
+    
+    <!-- CSS principal -->
+    <link rel="stylesheet" th:href="|${contextPath}/resources/css/main.css|" />
+  </th:block>
+</body>
+</html> 

--- a/src/main/webapp/WEB-INF/templates/home.html
+++ b/src/main/webapp/WEB-INF/templates/home.html
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="fr">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <th:block th:replace="~{fragments/head :: head}"></th:block>
     <title>Accueil - Color Run</title>
-    <link rel="stylesheet" th:href="|${contextPath}/resources/css/main.css|" />
   </head>
   <body>
     <!-- Header -->

--- a/src/main/webapp/WEB-INF/templates/login.html
+++ b/src/main/webapp/WEB-INF/templates/login.html
@@ -1,27 +1,8 @@
 <!DOCTYPE html>
 <html lang="fr" xmlns:th="http://www.thymeleaf.org">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title th:text="${pageTitle}">Connexion - Color Run</title>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            'color-primary': '#FF6B35',
-            'color-secondary': '#F7931E',
-            'color-accent': '#FFE135',
-            'color-pink': '#FF006E',
-            'color-purple': '#8338EC',
-            'color-blue': '#3A86FF',
-            'color-green': '#06FFA5',
-          }
-        }
-      }
-    }
-  </script>
+  <th:block th:replace="~{fragments/head :: head}"></th:block>
+  <title th:text="${pageTitle != null ? pageTitle : 'Connexion - Color Run'}">Connexion - Color Run</title>
 </head>
 <body class="min-h-screen bg-gray-50 flex items-center justify-center px-4">
 <div class="w-full max-w-md">

--- a/src/main/webapp/WEB-INF/templates/register.html
+++ b/src/main/webapp/WEB-INF/templates/register.html
@@ -1,27 +1,8 @@
 <!DOCTYPE html>
 <html lang="fr" xmlns:th="http://www.thymeleaf.org">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <th:block th:replace="~{fragments/head :: head}"></th:block>
   <title>Inscription - Color Run</title>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            'color-primary': '#FF6B35',
-            'color-secondary': '#F7931E',
-            'color-accent': '#FFE135',
-            'color-pink': '#FF006E',
-            'color-purple': '#8338EC',
-            'color-blue': '#3A86FF',
-            'color-green': '#06FFA5',
-          }
-        }
-      }
-    }
-  </script>
 </head>
 <body class="min-h-screen bg-gray-50 flex items-center justify-center px-4 py-8">
 <div class="w-full max-w-md">


### PR DESCRIPTION
This pull request refactors the HTML templates to centralize the `<head>` section into a reusable Thymeleaf fragment and applies it across multiple pages. Additionally, it introduces TailwindCSS for styling and removes redundant inline configurations from individual templates.

### Centralization of `<head>` Section:
* [`src/main/webapp/WEB-INF/templates/fragments/head.html`](diffhunk://#diff-4ec4a0a7f9e03f186943ca3dd9571f2e4dcbb6e8ca665e6b746100d8217d116bR1-R37): Created a new Thymeleaf fragment for the `<head>` section, including meta tags, page title logic, TailwindCSS integration, and a link to the main stylesheet.

### Updates to Individual Templates:
* `src/main/webapp/WEB-INF/templates/courses/list.html`, `dashboard.html`, `home.html`, `login.html`, `register.html`: Replaced inline `<head>` content with a reference to the new `head` fragment using `<th:block th:replace="~{fragments/head :: head}"></th:block>`. This ensures consistency and reduces duplication. [[1]](diffhunk://#diff-fede941fb171b6eaf4b56bb00f98479449663e793fc44427048899d4930256ebL4-L7) [[2]](diffhunk://#diff-e846cb19f5defee43c676c666189b3f3dcfc2121dad3041a5f33eab48ed495e5L4-R13) [[3]](diffhunk://#diff-d77916717cb322dd8243bf3786c99bfd309898ea173512368fea33bfec6542e6L4-L7) [[4]](diffhunk://#diff-249d107c76eadc3b12bae0534745e6080eec1bc7e1960078330b83705c0526ceL4-R5) [[5]](diffhunk://#diff-dba79f52c3c05fc825a290b9716c8824890508fe0a26df401d99e5900a6e4f7bL4-L24)

### Styling Enhancements:
* Introduced TailwindCSS in the `head` fragment, along with a custom theme configuration extending colors for the application. This eliminates the need for inline TailwindCSS scripts in individual templates.

### Minor Visual Update:
* [`src/main/webapp/WEB-INF/templates/dashboard.html`](diffhunk://#diff-e846cb19f5defee43c676c666189b3f3dcfc2121dad3041a5f33eab48ed495e5L4-R13): Added a `text-red-500` class to the dashboard title to demonstrate the use of TailwindCSS styling.